### PR TITLE
Enable geolocation permissions in Android webview

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     package="id.vouched.plugintest">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.webkit.PermissionRequest" />
     <uses-feature android:name="android.hardware.camera.autofocus" />
     <application


### PR DESCRIPTION
![Screenshot_20221004-142326](https://user-images.githubusercontent.com/91497219/193937500-bd7b7833-1f1a-4adc-b5de-62d4fb8a73d8.png)

Update the Chrome Webview Client to listen for geolocation permission requests, which apparently are treated differently than the other permission requests. When we capture a permission request, we use the native permissions facility to display the appropriate dialog

Specifically, this PR:
- Overrides `onGeolocationPermissionsShowPrompt` to request location permissions if necessary
- Extends the existing `onRequestPermissionsResult` to handle the permissions callback
